### PR TITLE
Add missing dependencies for Ubuntu 17.04 setup on some VPSs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ apt-get update && apt-get upgrade -y
 debconf-set-selections <<< "postfix postfix/mailname string ${VPNHOST}"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
 
-apt-get install -y language-pack-en strongswan libcharon-extra-plugins moreutils iptables-persistent postfix mailutils unattended-upgrades certbot
+apt-get install -y language-pack-en strongswan strongswan-ikev2 libstrongswan-standard-plugins strongswan-libcharon libcharon-standard-plugins libcharon-extra-plugins moreutils iptables-persistent postfix mailutils unattended-upgrades certbot
 
 
 ETH0ORSIMILAR=$(ip route get 8.8.8.8 | awk -- '{printf $5}')


### PR DESCRIPTION
Closes: https://github.com/jawj/IKEv2-setup/issues/12 by installing the missing strongswan and charon dependencies.