### PR TITLE
Increase iptables recent matching hitcount

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Bash script that takes Ubuntu Server 18.04 LTS (and probably also 17.10, 17.04
 
 * The VPN server identifies itself with a Let's Encrypt certificate, so there's no need for clients to install private certificates — they can simply authenticate with username and password (EAP-MSCHAPv2).
 * The box is firewalled with `iptables` and configured for unattended security upgrades, and the Let's Encrypt certificate is set up to auto-renew, so it should be safe to forget about it all until 18.04 reaches end-of-life in 2023.
+    * Iptables uses 'recent matching' to provent brute force or DDoS attacks on the box. Hosts that send more than 50 requests in a rolling 60 second period will be blocked for 60 seconds.
 * The cheapest VPSs offered by Linode, OVH, vps.ag and Vultr, and Scaleway's ARM64-2GB, have all been tested working as VPN servers. On Scaleway, unblock SMTP ports in the admin panel and *hard* reboot the server first, or your configuration email will not be delivered. On Vultr port 25 may also be blocked, but you won't know, and the only way to fix it is to open a support ticket.
 
 ### VPN clients

--- a/setup.sh
+++ b/setup.sh
@@ -124,7 +124,7 @@ iptables -A INPUT -m state --state INVALID -j DROP
 
 # rate-limit repeated new requests from same IP to any ports
 iptables -I INPUT -i $ETH0ORSIMILAR -m state --state NEW -m recent --set
-iptables -I INPUT -i $ETH0ORSIMILAR -m state --state NEW -m recent --update --seconds 60 --hitcount 12 -j DROP
+iptables -I INPUT -i $ETH0ORSIMILAR -m state --state NEW -m recent --update --seconds 60 --hitcount 50 -j DROP
 
 # accept (non-standard) SSH
 iptables -A INPUT -p tcp --dport $SSHPORT -j ACCEPT


### PR DESCRIPTION
The current iptables recent matching hitcount of 12 in 60 secs is too aggressive. This is causing issues in situations where you may need to connect/reconnect very fast (switching over to an internal network, then switching back, or utilizing the VPN in some automated process).

Additionally, this took me ages to figure what was going on as my VPN would sometimes "randomly" not work for only a single host. I've updated the README to explicitly let people know of this behavior.