### PR TITLE
Prefill .mobileconfig with VPN username and password

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -380,6 +380,10 @@ cat << EOF > vpn-ios-or-mac.mobileconfig
     <dict>
       <key>IKEv2</key>
       <dict>
+      	<key>AuthName</key>
+				<string>${VPNUSERNAME}</string>
+				<key>AuthPassword</key>
+				<string>${VPNPASSWORD}</string>
         <key>AuthenticationMethod</key>
         <string>None</string>
         <key>ChildSecurityAssociationParameters</key>


### PR DESCRIPTION
Added VPN username and password to .mobileconfig for iOS and Mac.  