### PR TITLE
Added IOS App connection proposal

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -263,8 +263,11 @@ conn roadwarrior
   forceencaps=yes
 
   # CNSA/RFC 6379 Suite B (https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites)
-  ike=aes256gcm16-prfsha384-ecp384!
-  esp=aes256gcm16-ecp384!
+  # ike=aes256gcm16-prfsha384-ecp384!
+  # esp=aes256gcm16-ecp384!
+  # For IOS connection 
+  ike=aes256-sha256-prfsha256-modp2048!
+  esp=aes256-sha256!
 
   dpdaction=clear
   dpddelay=900s


### PR DESCRIPTION
If you want to manage configuration by IOS Application this proposal settings will help to connect

I didn't find multi able proposal settings in the documentation of StrongSwan 

When I try to connect with original settings getting an error as follows

Aug 8 19:16:09 strongswan charon: 07[CFG] received proposals: IKE:AES_CBC_256/HMAC_SHA2_256_128/PRF_HMAC_SHA2_256/MODP_2048
Aug 8 19:16:09 strongswan charon: 07[CFG] configured proposals: IKE:AES_GCM_16_256/PRF_HMAC_SHA2_384/ECP_384
Aug 8 19:16:09 strongswan charon: 07[IKE] remote host is behind NAT
Aug 8 19:16:09 strongswan charon: 07[IKE] received proposals unacceptable