### PR TITLE
Fixed expired DST_Root_CA_X3.pem -> ISRG_Root_X1.pem in install script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -517,7 +517,7 @@ done
 apt-get install -y strongswan libstrongswan-standard-plugins libcharon-extra-plugins
 apt-get install -y libcharon-standard-plugins || true  # 17.04+ only
 
-ln -f -s /etc/ssl/certs/DST_Root_CA_X3.pem /etc/ipsec.d/cacerts/
+ln -f -s /etc/ssl/certs/ISRG_Root_X1.pem /etc/ipsec.d/cacerts/
 
 grep -Fq 'jawj/IKEv2-setup' /etc/ipsec.conf || echo "
 # https://github.com/jawj/IKEv2-setup


### PR DESCRIPTION
Fixed expired DST_Root_CA_X3.pem -> ISRG_Root_X1.pem in install script for Ubuntu client.

https://github.com/jawj/IKEv2-setup/issues/123

https://letsencrypt.org/ru/docs/dst-root-ca-x3-expiration-september-2021/